### PR TITLE
feat: fetch spdlog and fmt from repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,9 +76,19 @@ or a sink can be added to the library's logger:
 auto stdout_sink = std::make_shared<spdlog::sinks::stdout_color_sink_mt >();  liboculus::Logger::add_sink( stdout_sink );
 ```
 
+### Fetching `spdlog` and `fmt` to avoid dependencies
 
+Export the `FETCH_SPDLOG` variable to download and build static libraries for `spdlog` and `fmt`:
 
-
+```
+$ export FETCH_SPDLOG=1
+$ cmake ../ # In build directory
+[...]
+-- {fmt} version: 12.1.0
+-- Build type:
+-- Build spdlog: 1.17.0
+[...]
+```
 
 ---
 ## oc_client binary

--- a/cmake/BuildNonROS.cmake
+++ b/cmake/BuildNonROS.cmake
@@ -8,6 +8,23 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -march=native -Wl,--no-as-needed")
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/bin)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/lib)
 
+if(DEFINED ENV{FETCH_SPDLOG})
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
+
+    include(FetchContent)
+    FetchContent_Declare(
+      fmt
+      GIT_REPOSITORY https://github.com/fmtlib/fmt
+      GIT_TAG        407c905e45ad75fc29bf0f9bb7c5c2fd3475976f) # 12.1.0
+    FetchContent_MakeAvailable(fmt)
+
+    FetchContent_Declare(
+      spdlog
+      GIT_REPOSITORY https://github.com/gabime/spdlog
+      GIT_TAG        79524ddd08a4ec981b7fea76afd08ee05f83755d) # 1.17.0
+    FetchContent_MakeAvailable(spdlog)
+endif()
+
 # ###########################################
 # The following folders will be included  #
 # ###########################################


### PR DESCRIPTION
Hello, thank you for this library.

This PR adds support for fetching `spdlog` and `fmt` libraries without worrying about external dependencies.

I find this useful if the environment is not well aligned with the required revisions of these libraries.